### PR TITLE
mocker hentIdenter via graphql for PDL

### DIFF
--- a/src/pdl/resolver.ts
+++ b/src/pdl/resolver.ts
@@ -27,6 +27,11 @@ export default {
                         gruppe: 'FOLKEREGISTERIDENT',
                         historisk: false,
                     },
+                    {
+                        ident: 9876543210123,
+                        gruppe: 'AKTORID',
+                        historisk: false,
+                    },
                 ],
             };
         },


### PR DESCRIPTION
identen som sendes inn simpelthen returneres

fix: hentPerson kaster nå Error med "personen finnes ikke" (tidligere feilet den ved lesing av fil)