### PR TITLE
Nye personmocks for fødselshendelser

### DIFF
--- a/src/mocks/person_01062000001.json
+++ b/src/mocks/person_01062000001.json
@@ -1,0 +1,49 @@
+{
+    "foedsel": [
+        {
+            "foedselsdato": "2020-06-01"
+        }
+    ],
+    "navn": [
+        {
+            "fornavn": "Barn Hendelse",
+            "mellomnavn": null,
+            "etternavn": "Barnesen"
+        }
+    ],
+    "kjoenn": [
+        {
+            "kjoenn": "MANN"
+        }
+    ],
+    "familierelasjoner": [
+        {
+            "relatertPersonsIdent": "01129400001",
+            "relatertPersonsRolle": "MOR"
+        }
+    ],
+    "adressebeskyttelse": [],
+    "bostedsadresse": [
+        {
+            "ukjentBosted": null,
+            "vegadresse": {
+                "matrikkelId": 100,
+                "husnummer": "3",
+                "husbokstav": null,
+                "bruksenhetsnummer": "H111",
+                "adressenavn": "OTTO SVERDRUPS VEG",
+                "kommunenummer": "1566",
+                "tilleggsnavn": null,
+                "postnummer": "6650"
+            },
+            "matrikkeladresse": null
+        }
+    ],
+    "sivilstand": [
+        {
+            "type": "UGIFT"
+        }
+    ],
+    "doedsfall": [],
+    "vergemaalEllerFremtidsfullmakt": []
+}

--- a/src/mocks/person_01129400001.json
+++ b/src/mocks/person_01129400001.json
@@ -1,0 +1,49 @@
+{
+    "foedsel": [
+        {
+            "foedselsdato": "1994-12-01"
+        }
+    ],
+    "navn": [
+        {
+            "fornavn": "Mor Hendelse",
+            "mellomnavn": null,
+            "etternavn": "Moresen"
+        }
+    ],
+    "kjoenn": [
+        {
+            "kjoenn": "KVINNE"
+        }
+    ],
+    "familierelasjoner": [
+        {
+            "relatertPersonsIdent": "01062000001",
+            "relatertPersonsRolle": "BARN"
+        }
+    ],
+    "adressebeskyttelse": [],
+    "bostedsadresse": [
+        {
+            "ukjentBosted": null,
+            "vegadresse": {
+                "matrikkelId": 100,
+                "husnummer": "3",
+                "husbokstav": null,
+                "bruksenhetsnummer": "H111",
+                "adressenavn": "OTTO SVERDRUPS VEG",
+                "kommunenummer": "1566",
+                "tilleggsnavn": null,
+                "postnummer": "6650"
+            },
+            "matrikkeladresse": null
+        }
+    ],
+    "sivilstand": [
+        {
+            "type": "UGIFT"
+        }
+    ],
+    "doedsfall": [],
+    "vergemaalEllerFremtidsfullmakt": []
+}


### PR DESCRIPTION
Dette er to nye personmocks av mor / barn, som har en relasjon til hverandre.

Denne er udynamisk, og vil ikke lenger fungere i fødselshendelsetesten 01. desember.