### PR TITLE
Støttte for hent oppgaver, ferdigstill journalpost og oppdatering opp…

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -20,3 +20,5 @@ export const lesMockFil = (filnavn: string): string => {
         throw err;
     }
 };
+
+export let cachedFerdigstilte = new Map();

--- a/src/dokarkiv/dokarkiv.ts
+++ b/src/dokarkiv/dokarkiv.ts
@@ -1,5 +1,5 @@
 import { Express, Request, Response } from 'express';
-import { getId } from '../common';
+import { cachedFerdigstilte, getId } from '../common';
 
 export default (app: Express) => {
     app.post(
@@ -27,11 +27,18 @@ export default (app: Express) => {
     app.patch(
         '/rest/api/dokarkiv/rest/journalpostapi/v1/journalpost/:journalpostId/ferdigstill',
         (_req: Request, res: Response) => {
+            const { journalpostId } = _req.params;
+            cachedFerdigstilte.set(journalpostId, 'FERDIGSTILL');
             res.status(200).send('OK');
         },
     );
 
     app.get('/rest/api/dokarkiv/internal/isAlive', (_req: Request, res: Response) => {
+        res.status(200).send();
+    });
+
+    app.delete('/rest/api/dokarkiv/internal/ferdigstill/clear', (_req: Request, res: Response) => {
+        cachedFerdigstilte.clear();
         res.status(200).send();
     });
 };

--- a/src/mocks/journalpost_123454321_FERDIG.json
+++ b/src/mocks/journalpost_123454321_FERDIG.json
@@ -1,0 +1,50 @@
+{
+  "journalpostId": "123454321",
+  "journalposttype": "I",
+  "journalstatus": "JOURNALFOERT",
+  "tema": "BAR",
+  "behandlingstema": "ab0180",
+  "tittel": "Ordinær barnetrygd",
+  "sak": {
+    "arkivsaksnummer": "140260761",
+    "arkivsaksystem": "GSAK",
+    "fagsakId": "1001152",
+    "sakstype": null,
+    "fagsaksystem": "BA"
+  },
+  "bruker": {
+    "id": "12345678901",
+    "type": "FNR"
+  },
+  "journalforendeEnhet": "9999",
+  "kanal": "NAV_NO",
+  "dokumenter": [
+    {
+      "dokumentInfoId": "454002792",
+      "tittel": "Ordinær barnetrygd",
+      "brevkode": "NAV 33-00.07",
+      "dokumentstatus": null,
+      "dokumentvarianter": [
+        {
+          "variantformat": "ARKIV"
+        }
+      ],
+      "logiskeVedlegg": []
+    }
+  ],
+  "relevanteDatoer": [
+    {
+      "dato": "2020-06-11T15:19:59",
+      "datotype": "DATO_DOKUMENT"
+    },
+    {
+      "dato": "2020-06-11T15:20:10",
+      "datotype": "DATO_JOURNALFOERT"
+    },
+    {
+      "dato": "2020-03-26T01:00:00",
+      "datotype": "DATO_REGISTRERT"
+    }
+  ],
+  "datoMottatt": "2020-03-26T01:00:00"
+}

--- a/src/mocks/oppgaver.json
+++ b/src/mocks/oppgaver.json
@@ -1,0 +1,6 @@
+{
+  "antallTreffTotalt": 0,
+  "oppgaver": [
+
+  ]
+}

--- a/src/oppgave/oppgave.ts
+++ b/src/oppgave/oppgave.ts
@@ -1,13 +1,22 @@
 import { Express, Request, Response } from 'express';
 import { lesMockFil } from '../common';
 
+let cachedPostRequests = new Map();
+
 export default (app: Express) => {
+    const bodyParser = require('body-parser');
+    const jsonParser = bodyParser.json();
+
     const hentOppgave = () => {
         return lesMockFil(`oppgave_1.json`);
     };
 
+    const hentOppgaver = () => {
+        return lesMockFil(`oppgaver.json`);
+    };
+
     app.get('/rest/api/oppgave/api/v1/oppgaver', (_req: Request, res: Response) => {
-        res.json(hentOppgave());
+        res.json(hentOppgaver());
     });
 
     app.get('/rest/api/oppgave/api/v1/oppgaver/:oppgaveId', (_req: Request, res: Response) => {
@@ -18,15 +27,35 @@ export default (app: Express) => {
         res.json(hentOppgave());
     });
 
-    app.post('/rest/api/oppgave/api/v1/oppgaver', (_req: Request, res: Response) => {
+    app.post('/rest/api/oppgave/api/v1/oppgaver', jsonParser, (_req: Request, res: Response) => {
+        const callId = _req.header('Nav-Call-Id');
+        if (callId != undefined && callId != null) {
+            cachedPostRequests.set(callId, _req.body);
+        }
         res.json(hentOppgave());
     });
 
-    app.patch('/rest/api/oppgave/api/v1/oppgaver', (_req: Request, res: Response) => {
+    app.patch('/rest/api/oppgave/api/v1/oppgaver', jsonParser, (_req: Request, res: Response) => {
         res.json(hentOppgave());
     });
 
     app.get('/rest/api/oppgave/isAlive', (_req: Request, res: Response) => {
+        res.status(200).send();
+    });
+
+    app.get('/rest/api/oppgave/cache/:callId', (_req: Request, res: Response) => {
+        let { callId } = _req.params;
+        if (cachedPostRequests.has(callId)) {
+            res.json(cachedPostRequests.get(callId));
+        } else {
+            res.status(500).json({
+                message: `Fant ikke oppgave fra callId ` + callId,
+            });
+        }
+    });
+
+    app.delete('/rest/api/oppgave/cache/clear', (_req: Request, res: Response) => {
+        cachedPostRequests.clear();
         res.status(200).send();
     });
 };

--- a/src/saf/resolver.ts
+++ b/src/saf/resolver.ts
@@ -1,4 +1,4 @@
-import { lesMockFil } from '../common';
+import { cachedFerdigstilte, lesMockFil } from '../common';
 
 const hentJournalpost = (ident: string) => {
     try {
@@ -11,7 +11,13 @@ const hentJournalpost = (ident: string) => {
 export default {
     Query: {
         journalpost(_obj: any, args: any, _context: any, _info: any) {
-            const journalpost = hentJournalpost(args.journalpostId);
+            let journalpost = hentJournalpost(args.journalpostId);
+
+            if (cachedFerdigstilte.has(args.journalpostId)) {
+                journalpost = hentJournalpost(args.journalpostId + '_FERDIG');
+            } else {
+                journalpost = hentJournalpost(args.journalpostId);
+            }
 
             if (journalpost === undefined) {
                 throw new Error('Journalpost finnes ikke');


### PR DESCRIPTION
- Endret slik at finnOppgaver returnerer en liste med oppgaver.
- lagring i minne av post request for oppgave til en map, og endepunkter for å resette midlertidig cache og hente ned oppgaven basert på callId. Slik at man har mulighet til å teste på request.
- lagring i minne over journalposter som er ferdigstilt. Hvis man har gjort ferdigstilt på en journalpost, så vil man få returnert en journalpost med JOURNALFOERT status. Endepunkt for å resette cache