### PR TITLE
Mulighet til å sende med ident i ett scenario.

### DIFF
--- a/src/scenario/cache.ts
+++ b/src/scenario/cache.ts
@@ -24,7 +24,11 @@ export const genererFnr = (fødselsdato: string): string => {
 };
 
 export const lagScenarioForPerson = (restScenarioPerson: IRestScenarioPerson) => {
-    const ident: string = genererFnr(restScenarioPerson.fødselsdato);
+    const ident: string =
+        typeof restScenarioPerson.ident === 'undefined' || restScenarioPerson.ident === null
+            ? genererFnr(restScenarioPerson.fødselsdato)
+            : restScenarioPerson.ident;
+
     const restScenarioPersonMedIdenter = {
         ...restScenarioPerson,
         ident,

--- a/src/scenario/cache.ts
+++ b/src/scenario/cache.ts
@@ -24,10 +24,9 @@ export const genererFnr = (fødselsdato: string): string => {
 };
 
 export const lagScenarioForPerson = (restScenarioPerson: IRestScenarioPerson) => {
-    const ident: string =
-        typeof restScenarioPerson.ident === 'undefined' || restScenarioPerson.ident === null
-            ? genererFnr(restScenarioPerson.fødselsdato)
-            : restScenarioPerson.ident;
+    const ident: string = restScenarioPerson.ident
+        ? restScenarioPerson.ident
+        : genererFnr(restScenarioPerson.fødselsdato);
 
     const restScenarioPersonMedIdenter = {
         ...restScenarioPerson,


### PR DESCRIPTION
Mulighet til å sende med ident i ett scenario, slik at man ikke alltid får et nytt, men kan oppdatere et gammelt ett.

Dette for at man skal få lagd en institusjon-sak eller enslig mindreårig sak i ba-infotrygd, der hvor barnet og søker er det samme, og man trenger et eksisterende fnr for å få satt det opp.